### PR TITLE
Handle missing token boot errors

### DIFF
--- a/app/src/api.js
+++ b/app/src/api.js
@@ -101,7 +101,10 @@ export async function api(path, options = {}) {
 
   if (!response.ok) {
     const message = data?.error || data?.message || response.statusText;
-    throw new Error(message || 'Request failed');
+    const error = new Error(message || 'Request failed');
+    error.status = response.status;
+    error.data = data;
+    throw error;
   }
 
   return data;

--- a/app/src/context/AuthContext.js
+++ b/app/src/context/AuthContext.js
@@ -22,7 +22,8 @@ export function AuthProvider({ children }) {
       } catch (err) {
         await clearToken();
         setUser(null);
-        setBootError(err.message);
+        const isMissingToken = err?.status === 401 && String(err?.message).toLowerCase() === 'missing token';
+        setBootError(isMissingToken ? null : err?.message || 'Request failed');
       } finally {
         setLoading(false);
       }
@@ -41,6 +42,7 @@ export function AuthProvider({ children }) {
         });
         await setToken(data.token);
         setUser(data.user);
+        setBootError(null);
         return data.user;
       },
       register: async ({ email, password, role }) => {
@@ -50,11 +52,13 @@ export function AuthProvider({ children }) {
         });
         await setToken(data.token);
         setUser(data.user);
+        setBootError(null);
         return data.user;
       },
       signOut: async () => {
         await clearToken();
         setUser(null);
+        setBootError(null);
       }
     }),
     [user, loading, bootError]


### PR DESCRIPTION
## Summary
- attach response metadata to API errors so callers can branch on status codes
- suppress boot warnings when the /me request fails due to a missing token while keeping other errors visible
- clear boot errors after successful sign-in, registration, or sign-out to avoid stale warnings

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfcd6dad5c8324a52a854739148624