### PR TITLE
Refine API URL resolution in config

### DIFF
--- a/app/src/config.js
+++ b/app/src/config.js
@@ -1,3 +1,4 @@
+import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 
 // WEB -> backend na localhost:4000
@@ -6,7 +7,86 @@ import { Platform } from 'react-native';
 const DEV_WEB = 'http://localhost:4000';
 const DEV_ANDROID = 'http://10.0.2.2:4000';
 
-export const API_URL =
-  __DEV__
-    ? (Platform.OS === 'web' ? DEV_WEB : DEV_ANDROID)
-    : 'https://your-api.example.com';
+const devDefaultUrl = Platform.OS === 'web' ? DEV_WEB : DEV_ANDROID;
+
+const expoExtras =
+  Constants?.expoConfig?.extra ??
+  Constants?.expoConfig?.expoGo?.extra ??
+  Constants?.manifest2?.extra ??
+  Constants?.manifest?.extra ??
+  {};
+
+const explicitUrl =
+  process.env.EXPO_PUBLIC_API_URL ??
+  process.env.API_URL ??
+  expoExtras.apiUrl ??
+  expoExtras.API_URL ??
+  expoExtras.backendUrl ??
+  expoExtras.backendURL ??
+  null;
+
+function normaliseUrl(url) {
+  if (!url) {
+    return null;
+  }
+  return url.replace(/\/+$/, '');
+}
+
+function extractHostCandidate() {
+  const candidates = [
+    Constants?.expoConfig?.hostUri,
+    Constants?.expoConfig?.debuggerHost,
+    Constants?.manifest2?.extra?.expoGo?.developer?.url,
+    Constants?.manifest?.hostUri,
+    Constants?.manifest?.debuggerHost,
+    Constants?.expoGoConfig?.hostUri
+  ];
+
+  for (const value of candidates) {
+    if (typeof value !== 'string' || value.length === 0) {
+      continue;
+    }
+
+    const withoutProtocol = value.replace(/^(https?:\/\/)/, '');
+    const [hostPart] = withoutProtocol.split(/[/?#]/);
+    if (!hostPart) {
+      continue;
+    }
+
+    const [hostname] = hostPart.split(':');
+    if (hostname) {
+      return hostname;
+    }
+  }
+
+  return null;
+}
+
+function buildUrlFromHost(host) {
+  if (!host) {
+    return null;
+  }
+
+  try {
+    const base = new URL(devDefaultUrl);
+    const portSegment = base.port ? `:${base.port}` : '';
+    return `${base.protocol}//${host}${portSegment}`;
+  } catch (error) {
+    // W razie problemów z parsowaniem URL korzystamy z domyślnych wartości dev.
+    const fallback = normaliseUrl(devDefaultUrl);
+    return fallback ?? null;
+  }
+}
+
+const hostFromExpo = buildUrlFromHost(extractHostCandidate());
+
+const resolvedApiUrl = normaliseUrl(explicitUrl ?? hostFromExpo ?? devDefaultUrl);
+
+if (!explicitUrl) {
+  console.warn(
+    '[config] API_URL nie zostało skonfigurowane. Korzystam z adresu domyślnego',
+    resolvedApiUrl
+  );
+}
+
+export const API_URL = resolvedApiUrl;


### PR DESCRIPTION
## Summary
- derive the API base URL from explicit configuration or Expo host information instead of a hard-coded production value
- add a warning fallback so missing configuration is easier to spot in production builds

## Testing
- Not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cfd112983c8324a7ca85aa586f9322