### PR TITLE
Handle missing token without boot errors

### DIFF
--- a/app/src/api.js
+++ b/app/src/api.js
@@ -101,7 +101,10 @@ export async function api(path, options = {}) {
 
   if (!response.ok) {
     const message = data?.error || data?.message || response.statusText;
-    throw new Error(message || 'Request failed');
+    const error = new Error(message || 'Request failed');
+    error.status = response.status;
+    error.data = data;
+    throw error;
   }
 
   return data;

--- a/app/src/context/AuthContext.js
+++ b/app/src/context/AuthContext.js
@@ -22,7 +22,12 @@ export function AuthProvider({ children }) {
       } catch (err) {
         await clearToken();
         setUser(null);
-        setBootError(err.message);
+        const isMissingToken = err?.status === 401 && err?.message === 'missing token';
+        if (isMissingToken) {
+          setBootError(null);
+        } else {
+          setBootError(err.message);
+        }
       } finally {
         setLoading(false);
       }
@@ -41,6 +46,7 @@ export function AuthProvider({ children }) {
         });
         await setToken(data.token);
         setUser(data.user);
+        setBootError(null);
         return data.user;
       },
       register: async ({ email, password, role }) => {
@@ -50,6 +56,7 @@ export function AuthProvider({ children }) {
         });
         await setToken(data.token);
         setUser(data.user);
+        setBootError(null);
         return data.user;
       },
       signOut: async () => {


### PR DESCRIPTION
## Summary
- avoid persisting boot errors when /me returns a missing token response
- reset boot error state after successful sign-in or registration
- expose HTTP status and payload on API errors for downstream handling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfd11d79c88324afe5663341224ae3