### PR TITLE
Improve auth boot error handling

### DIFF
--- a/app/src/api.js
+++ b/app/src/api.js
@@ -101,7 +101,10 @@ export async function api(path, options = {}) {
 
   if (!response.ok) {
     const message = data?.error || data?.message || response.statusText;
-    throw new Error(message || 'Request failed');
+    const error = new Error(message || 'Request failed');
+    error.status = response.status;
+    error.data = data;
+    throw error;
   }
 
   return data;

--- a/app/src/context/AuthContext.js
+++ b/app/src/context/AuthContext.js
@@ -19,10 +19,19 @@ export function AuthProvider({ children }) {
       try {
         const data = await api('/me');
         setUser(data.user);
+        setBootError(null);
       } catch (err) {
-        await clearToken();
+        const isMissingToken =
+          err?.status === 401 && (err?.message === 'missing token' || err?.data?.error === 'missing token');
+
+        if (!isMissingToken) {
+          await clearToken();
+          setBootError(err?.message || 'Request failed');
+        } else {
+          setBootError(null);
+        }
+
         setUser(null);
-        setBootError(err.message);
       } finally {
         setLoading(false);
       }
@@ -41,6 +50,7 @@ export function AuthProvider({ children }) {
         });
         await setToken(data.token);
         setUser(data.user);
+        setBootError(null);
         return data.user;
       },
       register: async ({ email, password, role }) => {
@@ -50,11 +60,13 @@ export function AuthProvider({ children }) {
         });
         await setToken(data.token);
         setUser(data.user);
+        setBootError(null);
         return data.user;
       },
       signOut: async () => {
         await clearToken();
         setUser(null);
+        setBootError(null);
       }
     }),
     [user, loading, bootError]


### PR DESCRIPTION
## Summary
- clear authentication boot errors after a successful /me call so stale warnings disappear
- treat 401 missing-token responses as a normal boot scenario while still surfacing real faults
- reset the boot error message on sign-out alongside clearing the stored user

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfd11d79c88324afe5663341224ae3